### PR TITLE
Allow overriding model checkpoint dir at runtime.

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -8,11 +8,13 @@ export PYTHONPATH="`pwd`/tensorflow_models/research/slim:$PYTHONPATH"
 protoc protos/*.proto --python_out=. || exit -1
 
 mkdir -p log
+mkdir -p checkpoints
 
 export CUDA_VISIBLE_DEVICES=2
 name="448"
 python train/trainer_main.py \
   --pipeline_proto="configs/${name}.pbtxt" \
+  --model_dir="checkpoints/${name}" \
   --logtostderr >> log/${name}.log 2>&1 &
 
 exit 0

--- a/train/trainer_main.py
+++ b/train/trainer_main.py
@@ -1,4 +1,3 @@
-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -14,11 +13,12 @@ flags = tf.app.flags
 
 tf.logging.set_verbosity(tf.logging.INFO)
 
-flags.DEFINE_string('type', 
-    '', 'A message string passed from command-line.')
+flags.DEFINE_string('type', '', 'A message string passed from command-line.')
 
-flags.DEFINE_string('pipeline_proto', 
-    '', 'Path to the pipeline proto file.')
+flags.DEFINE_string('pipeline_proto', '', 'Path to the pipeline proto file.')
+
+flags.DEFINE_string('model_dir', '',
+                    'Path to the directory which holds model checkpoints.')
 
 FLAGS = flags.FLAGS
 
@@ -40,12 +40,18 @@ def _load_pipeline_proto(filename):
 
 def main(_):
   pipeline_proto = _load_pipeline_proto(FLAGS.pipeline_proto)
+
+  if FLAGS.model_dir:
+    pipeline_proto.model_dir = FLAGS.model_dir
+    tf.logging.info("Override model checkpoint dir: %s", FLAGS.model_dir)
+
   tf.logging.info("Pipeline configure: %s", '=' * 128)
   tf.logging.info(pipeline_proto)
 
   trainer.create_train_and_evaluate(pipeline_proto)
 
   tf.logging.info('Done')
+
 
 if __name__ == '__main__':
   tf.app.run()


### PR DESCRIPTION
Add a flag "model_dir" for trainer_main.py to allow overriding model checkpoint dir in proto configs.